### PR TITLE
Proposal: Replace default color value with currentColor

### DIFF
--- a/docs/src/components/cards.tsx
+++ b/docs/src/components/cards.tsx
@@ -13,17 +13,17 @@ export default () => (
   <>
     <div className="w-full">
       <Card title="Tilt">
-        <Hamburger size={36} color="white" direction="right" />
+        <Hamburger size={36} direction="right" />
         <div>
           import
           <span className="text-white"> Hamburger </span>
           from '<span className="text-green-400">hamburger-react</span>'
         </div>
-        <Hamburger size={36} color="white" />
+        <Hamburger size={36} />
       </Card>
 
       <Card title="Fade">
-        <Fade size={36} color="white" direction="right" />
+        <Fade size={36} direction="right" />
         <div>
           import {'{'}
           <span className="text-white"> Fade </span>
@@ -31,11 +31,11 @@ export default () => (
           <span className="text-white"> Hamburger </span>
           {'}'} from '<span className="text-green-400">hamburger-react</span>'
         </div>
-        <Fade size={36} color="white" />
+        <Fade size={36} />
       </Card>
 
       <Card title="Twirl">
-        <Twirl size={36} color="white" direction="right" />
+        <Twirl size={36} direction="right" />
         <div>
           import {'{'}
           <span className="text-white"> Twirl </span>
@@ -43,11 +43,11 @@ export default () => (
           <span className="text-white"> Hamburger </span>
           {'}'} from '<span className="text-green-400">hamburger-react</span>'
         </div>
-        <Twirl size={36} color="white" />
+        <Twirl size={36} />
       </Card>
 
       <Card title="Turn">
-        <Turn size={36} color="white" direction="right" />
+        <Turn size={36} direction="right" />
         <div>
           import {'{'}
           <span className="text-white"> Turn </span>
@@ -55,11 +55,11 @@ export default () => (
           <span className="text-white"> Hamburger </span>
           {'}'} from '<span className="text-green-400">hamburger-react</span>'
         </div>
-        <Turn size={36} color="white" />
+        <Turn size={36} />
       </Card>
 
       <Card title="Sling">
-        <Sling size={36} color="white" direction="right" />
+        <Sling size={36} direction="right" />
         <div>
           import {'{'}
           <span className="text-white"> Sling </span>
@@ -67,11 +67,11 @@ export default () => (
           <span className="text-white"> Hamburger </span>
           {'}'} from '<span className="text-green-400">hamburger-react</span>'
         </div>
-        <Sling size={36} color="white" />
+        <Sling size={36} />
       </Card>
 
       <Card title="Spin">
-        <Spin size={36} color="white" direction="right" />
+        <Spin size={36} direction="right" />
         <div>
           import {'{'}
           <span className="text-white"> Spin </span>
@@ -79,11 +79,11 @@ export default () => (
           <span className="text-white"> Hamburger </span>
           {'}'} from '<span className="text-green-400">hamburger-react</span>'
         </div>
-        <Spin size={36} color="white" />
+        <Spin size={36} />
       </Card>
 
       <NewCard title="Squash">
-        <Squash size={36} color="white" />
+        <Squash size={36} />
         <div>
           import {'{'}
           <span className="text-white"> Squash </span>

--- a/docs/src/components/properties.tsx
+++ b/docs/src/components/properties.tsx
@@ -89,8 +89,8 @@ export default () => {
 
         <Example>
           <Property name="size" initial="32" type="integer" />
-          <Hamburger size={20} />A number between 12 and 48, which
-          sets the size of the icon.
+          <Hamburger size={20} />A number between 12 and 48, which sets the size
+          of the icon.
           <div>
             {'<'}
             <span className="text-yellow-400">Hamburger</span>
@@ -106,8 +106,8 @@ export default () => {
             <Property name="toggled" initial="undefined" type="boolean" />
             <Property name="toggle" initial="undefined" type="function" />
           </div>
-          <Hamburger size={34} toggled={isOpen} toggle={setOpen} />
-          A way to provide your own state.
+          <Hamburger size={34} toggled={isOpen} toggle={setOpen} />A way to
+          provide your own state.
           <div>
             <span className="text-purple-400">const</span>
             &nbsp;

--- a/docs/src/components/properties.tsx
+++ b/docs/src/components/properties.tsx
@@ -13,7 +13,7 @@ export default () => {
 
       <div className="w-full max-w-xl">
         <Example>
-          <Property name="color" initial="#000" type="string" />
+          <Property name="color" initial="currentColor" type="string" />
           <Hamburger color="#4FD1C5" size={34} />
           The color of the icon bars, accepts any CSS-parsable argument.
           <div>
@@ -28,7 +28,7 @@ export default () => {
 
         <Example>
           <Property name="direction" initial="left" type="string" />
-          <Hamburger color="white" direction="right" size={30} />
+          <Hamburger direction="right" size={30} />
           The animation direction of the icon, left or right.
           <div>
             {'<'}
@@ -47,7 +47,7 @@ export default () => {
             type="float / integer"
             smallType="float / int"
           />
-          <Hamburger color="white" duration={0.8} size={26} />
+          <Hamburger duration={0.8} size={26} />
           The duration of the animation. Can be set to zero if no animation is
           desired.
           <div>
@@ -62,7 +62,7 @@ export default () => {
 
         <Example>
           <Property name="hideOutline" initial="true" type="boolean" />
-          <Hamburger color="white" hideOutline={false} size={30} />
+          <Hamburger hideOutline={false} size={30} />
           Hides the default browser focus style.
           <div>
             {'<'}
@@ -76,7 +76,7 @@ export default () => {
 
         <Example>
           <Property name="rounded" initial="false" type="boolean" />
-          <Hamburger color="white" rounded size={42} />
+          <Hamburger rounded size={42} />
           Specifies if the icon bars should be rounded.
           <div>
             {'<'}
@@ -89,7 +89,7 @@ export default () => {
 
         <Example>
           <Property name="size" initial="32" type="integer" />
-          <Hamburger color="white" size={20} />A number between 12 and 48, which
+          <Hamburger size={20} />A number between 12 and 48, which
           sets the size of the icon.
           <div>
             {'<'}
@@ -106,12 +106,7 @@ export default () => {
             <Property name="toggled" initial="undefined" type="boolean" />
             <Property name="toggle" initial="undefined" type="function" />
           </div>
-          <Hamburger
-            color="white"
-            size={34}
-            toggled={isOpen}
-            toggle={setOpen}
-          />
+          <Hamburger size={34} toggled={isOpen} toggle={setOpen} />
           A way to provide your own state.
           <div>
             <span className="text-purple-400">const</span>
@@ -144,7 +139,6 @@ export default () => {
         <Example last>
           <Property name="onToggle" initial="undefined" type="function" />
           <Hamburger
-            color="white"
             size={26}
             onToggle={(toggled) =>
               console.log('🍔 [hamburger-react] toggled:', toggled)

--- a/docs/src/components/property.tsx
+++ b/docs/src/components/property.tsx
@@ -61,7 +61,7 @@ export default ({
         justify-center
         text-center
         sm:mr-6
-        w-20
+        w-24
         border-solid
       "
       >

--- a/src/Burger.tsx
+++ b/src/Burger.tsx
@@ -6,7 +6,7 @@ const timing = 'cubic-bezier(0, 0, 0, 1)'
 const translate = 4.6325
 
 export const Burger = (({
-  color = '#000',
+  color = 'currentColor',
   direction = 'left',
   duration = 0.4,
   hideOutline = true,

--- a/tests/color.test.tsx
+++ b/tests/color.test.tsx
@@ -2,6 +2,12 @@ import React from 'react'
 import Hamburger from '../src'
 import { render } from '@testing-library/react'
 
+it(`inherits the color from its parent by default`, () => {
+  const { getByTestId: get } = render(<Hamburger />)
+
+  expect(get('bar-one')).toHaveStyle({ background: 'currentColor' })
+})
+
 it(`sets the correct color`, () => {
   const { getByTestId: get } = render(<Hamburger color="pink" />)
 


### PR DESCRIPTION
Following the TypeScript changes I was excited to be able to utilize the package, but I immediately noticed the default value for the `color` property being slightly non-intuitive.

`currentColor` is a [well-supported value](https://caniuse.com/#feat=currentcolor) for `backgrund-color` and other similar CSS properties, referring to the element's current `color`. Using this value as the default lets developers keep the code DRY while integrating the burger icon with  their projects by eliminating the need to duplicate color values that already come from the page's CSS.