### PR TITLE
Check if user provided `toggle` is defined

### DIFF
--- a/src/Burger.tsx
+++ b/src/Burger.tsx
@@ -65,8 +65,8 @@ export const Burger = (({
     barStyles['borderRadius'] = '9em'
   }
 
-  const toggleFunction = toggle ? toggle : toggleInternal
-  const isToggled = toggled ? toggled : toggledInternal
+  const toggleFunction = toggle ?? toggleInternal
+  const isToggled = toggled ?? toggledInternal
 
   const handler = () => {
     toggleFunction(!isToggled)

--- a/src/Burger.tsx
+++ b/src/Burger.tsx
@@ -65,8 +65,8 @@ export const Burger = (({
     barStyles['borderRadius'] = '9em'
   }
 
-  const toggleFunction = toggle ?? toggleInternal
-  const isToggled = toggled ?? toggledInternal
+  const toggleFunction = toggle != null ? toggle : toggleInternal
+  const isToggled = toggled != null ? toggled : toggledInternal
 
   const handler = () => {
     toggleFunction(!isToggled)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "jsx": "react",
+    "skipLibCheck": true,
     "moduleResolution": "Node",
     "outDir": "./dist-types",
     "strict": true,


### PR DESCRIPTION
Currently this is done using a ternary, which is incorrectly using `toggleInternal`
when `toggle` is set to `false`. Update to using nullish coallescing to check if
`toggle` is defined rather than falsey.