### PR TITLE
Add event to toggle handlers

### DIFF
--- a/src/Burger.tsx
+++ b/src/Burger.tsx
@@ -68,10 +68,10 @@ export const Burger = (({
   const toggleFunction = toggle || toggleInternal
   const isToggled = toggled !== undefined ? toggled : toggledInternal
 
-  const handler = () => {
-    toggleFunction(!isToggled)
+  const handler = (e) => {
+    toggleFunction(!isToggled, e)
 
-    if (typeof onToggle === 'function') onToggle(!isToggled)
+    if (typeof onToggle === 'function') onToggle(!isToggled, e)
   }
 
   return render({

--- a/tests/onToggle.test.tsx
+++ b/tests/onToggle.test.tsx
@@ -1,22 +1,24 @@
 import React from 'react'
 import Hamburger from '../src'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, createEvent, render, screen } from '@testing-library/react'
 
 it(`fires the callback with correct arguments`, () => {
   const onToggle = jest.fn()
   render(<Hamburger onToggle={onToggle} />)
 
-  fireEvent.click(screen.getByTestId('tilt'))
-  expect(onToggle).toHaveBeenCalledWith(true)
+  const clickEvent = createEvent.click(screen.getByTestId('tilt')) 
+  fireEvent(screen.getByTestId('tilt'), clickEvent)
+  expect(onToggle).toHaveBeenCalledWith(true, expect.objectContaining({ nativeEvent: clickEvent }))
 
-  fireEvent.click(screen.getByTestId('tilt'))
-  expect(onToggle).toHaveBeenCalledWith(false)
+  fireEvent(screen.getByTestId('tilt'), clickEvent)
+  expect(onToggle).toHaveBeenCalledWith(false, expect.objectContaining({ nativeEvent: clickEvent }))
 })
 
 it(`fires when state value and action are provided`, () => {
   const onToggle = jest.fn()
   render(<Hamburger toggled={true} toggle={jest.fn()} onToggle={onToggle} />)
 
-  fireEvent.click(screen.getByTestId('tilt'))
-  expect(onToggle).toHaveBeenCalledWith(false)
+  const clickEvent = createEvent.click(screen.getByTestId('tilt')) 
+  fireEvent(screen.getByTestId('tilt'), clickEvent)
+  expect(onToggle).toHaveBeenCalledWith(false, expect.objectContaining({ nativeEvent: clickEvent }))
 })

--- a/tests/toggle.test.tsx
+++ b/tests/toggle.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import Hamburger from '../src'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, createEvent, render, screen } from '@testing-library/react'
 
 it(`fires the action with correct arguments`, () => {
   const toggle = jest.fn()
   render(<Hamburger toggled={false} toggle={toggle} />)
 
-  fireEvent.click(screen.getByTestId('tilt'))
-  expect(toggle).toHaveBeenCalledWith(true)
+  const clickEvent = createEvent.click(screen.getByTestId('tilt')) 
+  fireEvent(screen.getByTestId('tilt'), clickEvent)
+  expect(toggle).toHaveBeenCalledWith(true, expect.objectContaining({ nativeEvent: clickEvent }))
 })


### PR DESCRIPTION
Hi there, great library!

I have a use case for handling the click event of the hamburger component. I've gone ahead and suggested a way to incorporate it into the api, as a second argument to `toggle` and `onToggled`, let me know what you think!