### PR TITLE
feat: use transform only transitions

### DIFF
--- a/src/Burger.tsx
+++ b/src/Burger.tsx
@@ -45,7 +45,7 @@ export const Burger = (({
     cursor: 'pointer',
     height: `${area}px`,
     position: 'relative',
-    transition: `${time}s ${easing}`,
+    transition: `transform ${time}s ${easing}`,
     userSelect: 'none',
     width: `${area}px`,
   }

--- a/src/Cross.tsx
+++ b/src/Cross.tsx
@@ -19,7 +19,7 @@ export const Cross = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? -1 : 1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move}px)`
           : 'none'
@@ -30,7 +30,7 @@ export const Cross = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight + o.margin}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? 1 : -1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move * -1}px)`
           : 'none'

--- a/src/Divide.tsx
+++ b/src/Divide.tsx
@@ -20,7 +20,7 @@ export const Divide = ((props) => (
         width: `${o.width / 2}px`,
         borderRadius: `${o.barStyles.borderRadius} 0 0 ${o.barStyles.borderRadius}`,
         top: `${o.topOffset}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `translate(${o.move * 0.48}px, ${o.move * 0.73}px) rotate(45deg)`
           : 'none'
@@ -33,7 +33,7 @@ export const Divide = ((props) => (
         borderRadius: `0 ${o.barStyles.borderRadius} ${o.barStyles.borderRadius} 0`,
         left: '50%',
         top: `${o.topOffset}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `translate(-${o.move * 0.48}px, ${o.move * 0.73}px) rotate(-45deg)`
           : 'none'
@@ -45,7 +45,7 @@ export const Divide = ((props) => (
         width: `${o.width / 2}px`,
         borderRadius: `${o.barStyles.borderRadius} 0 0 ${o.barStyles.borderRadius}`,
         top: `${o.topOffset + o.barHeight + o.margin}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         opacity: o.isToggled ? 0 : 1,
         transform: `${o.isToggled
           ? `translate(${-o.move * 1.25}px, 0)`
@@ -59,7 +59,7 @@ export const Divide = ((props) => (
         borderRadius: `0 ${o.barStyles.borderRadius} ${o.barStyles.borderRadius} 0`,
         top: `${o.topOffset + o.barHeight + o.margin}px`,
         left: '50%',
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         opacity: o.isToggled ? 0 : 1,
         transform: `${o.isToggled
           ? `translate(${o.move * 1.25}px, 0)`
@@ -72,7 +72,7 @@ export const Divide = ((props) => (
         width: `${o.width / 2}px`,
         borderRadius: `${o.barStyles.borderRadius} 0 0 ${o.barStyles.borderRadius}`,
         top: `${o.topOffset + o.barHeight * 2 + o.margin * 2}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `translate(${o.move * 0.48}px, -${o.move * 0.73}px) rotate(-45deg)`
           : 'none'
@@ -85,7 +85,7 @@ export const Divide = ((props) => (
         borderRadius: `0 ${o.barStyles.borderRadius} ${o.barStyles.borderRadius} 0`,
         left: '50%',
         top: `${o.topOffset + o.barHeight * 2 + o.margin * 2}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `translate(-${o.move * 0.48}px, -${o.move * 0.73}px) rotate(45deg)`
           : 'none'

--- a/src/Fade.tsx
+++ b/src/Fade.tsx
@@ -19,7 +19,7 @@ export const Fade = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? -1 : 1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move}px)`
           : 'none'
@@ -30,7 +30,7 @@ export const Fade = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight + o.margin}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         opacity: `${o.isToggled
           ? '0'
           : '1'
@@ -41,7 +41,7 @@ export const Fade = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight * 2 + o.margin * 2}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? 1 : -1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move * -1}px)`
           : 'none'

--- a/src/Pivot.tsx
+++ b/src/Pivot.tsx
@@ -22,7 +22,7 @@ export const Pivot = ((props) => (
       tabIndex={0}
     >
       <div data-testid="bar-wrap-one" style={{
-        transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+        transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
           ? '0s'
           : `${o.time / 2}s`
         }`,
@@ -35,7 +35,7 @@ export const Pivot = ((props) => (
           ...o.barStyles,
           width: `${o.width}px`,
           top: `${o.topOffset}px`,
-          transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+          transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
             ? `${o.time / 2}s`
             : '0s'
           }`,
@@ -47,7 +47,7 @@ export const Pivot = ((props) => (
       </div>
 
       <div data-testid="bar-wrap-two" style={{
-        transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+        transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
           ? '0s'
           : `${o.time / 2}s`
         }`,
@@ -60,7 +60,7 @@ export const Pivot = ((props) => (
           ...o.barStyles,
           width: `${o.width}px`,
           top: `${o.topOffset + o.barHeight + o.margin}px`,
-          transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+          transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
             ? `${o.time / 2}s`
             : '0s'
           }`,

--- a/src/Rotate.tsx
+++ b/src/Rotate.tsx
@@ -25,7 +25,7 @@ export const Rotate = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? -1 : 1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move}px)`
           : 'none'
@@ -36,7 +36,7 @@ export const Rotate = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight + o.margin}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? 1 : -1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move * -1}px)`
           : 'none'

--- a/src/Slant.tsx
+++ b/src/Slant.tsx
@@ -25,7 +25,7 @@ export const Slant = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? -1 : 1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move}px)`
           : 'none'
@@ -36,7 +36,7 @@ export const Slant = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight + o.margin}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? 1 : -1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move * -1}px)`
           : 'none'

--- a/src/Sling.tsx
+++ b/src/Sling.tsx
@@ -25,7 +25,7 @@ export const Sling = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? -1 : 1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move}px)`
           : 'none'
@@ -36,7 +36,7 @@ export const Sling = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight + o.margin}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `scale(0, 1) translate(${(o.move * 20) * (o.isLeft ? -1 : 1)}px, 0)`
           : 'none'
@@ -47,7 +47,7 @@ export const Sling = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight * 2 + o.margin * 2}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? 1 : -1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move * -1}px)`
           : 'none'

--- a/src/Spin.tsx
+++ b/src/Spin.tsx
@@ -25,7 +25,7 @@ export const Spin = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? -1 : 1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move}px)`
           : 'none'
@@ -36,7 +36,7 @@ export const Spin = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight + o.margin}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         opacity: `${o.isToggled
           ? '0'
           : '1'
@@ -47,7 +47,7 @@ export const Spin = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight * 2 + o.margin * 2}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? 1 : -1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move * -1}px)`
           : 'none'

--- a/src/Spiral.tsx
+++ b/src/Spiral.tsx
@@ -25,7 +25,7 @@ export const Spiral = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? -1 : 1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move}px)`
           : 'none'
@@ -36,7 +36,7 @@ export const Spiral = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight + o.margin}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? 1 : -1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move * -1}px)`
           : 'none'

--- a/src/Squash.tsx
+++ b/src/Squash.tsx
@@ -16,7 +16,7 @@ export const Squash = ((props) => (
       tabIndex={0}
     >
       <div data-testid="bar-wrap-one" style={{
-        transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+        transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
           ? '0s'
           : `${o.time / 2}s`
         }`,
@@ -29,7 +29,7 @@ export const Squash = ((props) => (
           ...o.barStyles,
           width: `${o.width}px`,
           top: `${o.topOffset}px`,
-          transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+          transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
             ? `${o.time / 2}s`
             : '0s'
           }`,
@@ -41,7 +41,7 @@ export const Squash = ((props) => (
       </div>
 
       <div data-testid="bar-wrap-two" style={{
-        transition: `${o.time / 2}s ${o.easing}`,
+        transition: `transform ${o.time / 2}s ${o.easing}`,
         opacity: `${o.isToggled
           ? '0'
           : '1'
@@ -51,12 +51,12 @@ export const Squash = ((props) => (
           ...o.barStyles,
           width: `${o.width}px`,
           top: `${o.topOffset + o.barHeight + o.margin}px`,
-          transition: `${o.time / 2}s ${o.easing}`,
+          transition: `transform ${o.time / 2}s ${o.easing}`,
         }} />
       </div>
 
       <div data-testid="bar-wrap-three" style={{
-        transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+        transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
           ? '0s'
           : `${o.time / 2}s`
         }`,
@@ -69,7 +69,7 @@ export const Squash = ((props) => (
           ...o.barStyles,
           width: `${o.width}px`,
           top: `${o.topOffset + o.barHeight * 2 + o.margin * 2}px`,
-          transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+          transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
             ? `${o.time / 2}s`
             : '0s'
           }`,

--- a/src/Squeeze.tsx
+++ b/src/Squeeze.tsx
@@ -16,7 +16,7 @@ export const Squeeze = ((props) => (
       tabIndex={0}
     >
       <div data-testid="bar-wrap-one" style={{
-        transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+        transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
           ? '0s'
           : `${o.time / 2}s`
         }`,
@@ -29,7 +29,7 @@ export const Squeeze = ((props) => (
           ...o.barStyles,
           width: `${o.width}px`,
           top: `${o.topOffset}px`,
-          transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+          transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
             ? `${o.time / 2}s`
             : '0s'
           }`,
@@ -41,7 +41,7 @@ export const Squeeze = ((props) => (
       </div>
 
       <div data-testid="bar-wrap-three" style={{
-        transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+        transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
           ? '0s'
           : `${o.time / 2}s`
         }`,
@@ -54,7 +54,7 @@ export const Squeeze = ((props) => (
           ...o.barStyles,
           width: `${o.width}px`,
           top: `${o.topOffset + o.barHeight + o.margin}px`,
-          transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+          transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
             ? `${o.time / 2}s`
             : '0s'
           }`,

--- a/src/Tilt.tsx
+++ b/src/Tilt.tsx
@@ -25,7 +25,7 @@ export const Tilt = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? -1 : 1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move}px)`
           : 'none'
@@ -36,7 +36,7 @@ export const Tilt = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight + o.margin}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? 'scaleX(0)'
           : 'none'
@@ -47,7 +47,7 @@ export const Tilt = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight * 2 + o.margin * 2}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? 1 : -1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move * -1}px)`
           : 'none'

--- a/src/Turn.tsx
+++ b/src/Turn.tsx
@@ -19,7 +19,7 @@ export const Turn = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? -1 : 1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move}px)`
           : 'none'
@@ -30,7 +30,7 @@ export const Turn = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight + o.margin}px`,
-        transition: `${o.time / 2}s ${o.easing}`,
+        transition: `transform ${o.time / 2}s ${o.easing}`,
         transform: `${o.isToggled
           ? 'scaleX(0)'
           : 'none'
@@ -41,7 +41,7 @@ export const Turn = ((props) => (
         ...o.barStyles,
         width: `${o.width}px`,
         top: `${o.topOffset + o.barHeight * 2 + o.margin * 2}px`,
-        transition: `${o.time}s ${o.easing}`,
+        transition: `transform ${o.time}s ${o.easing}`,
         transform: `${o.isToggled
           ? `rotate(${45 * (o.isLeft ? 1 : -1)}deg) translate(${o.move * (o.isLeft ? -1 : 1)}px, ${o.move * -1}px)`
           : 'none'

--- a/src/Twirl.tsx
+++ b/src/Twirl.tsx
@@ -22,7 +22,7 @@ export const Twirl = ((props) => (
       tabIndex={0}
     >
       <div style={{
-        transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+        transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
           ? '0s'
           : `${o.time / 2}s`
         }`,
@@ -35,7 +35,7 @@ export const Twirl = ((props) => (
           ...o.barStyles,
           width: `${o.width}px`,
           top: `${o.topOffset}px`,
-          transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+          transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
             ? `${o.time / 2}s`
             : '0s'
           }`,
@@ -47,7 +47,7 @@ export const Twirl = ((props) => (
       </div>
 
       <div style={{
-        transition: `${o.time / 2}s ${o.easing}`,
+        transition: `transform ${o.time / 2}s ${o.easing}`,
         opacity: `${o.isToggled
           ? '0'
           : '1'
@@ -57,12 +57,12 @@ export const Twirl = ((props) => (
           ...o.barStyles,
           width: `${o.width}px`,
           top: `${o.topOffset + o.barHeight + o.margin}px`,
-          transition: `${o.time / 2}s ${o.easing}`,
+          transition: `transform ${o.time / 2}s ${o.easing}`,
         }} />
       </div>
 
       <div style={{
-        transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+        transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
           ? '0s'
           : `${o.time / 2}s`
         }`,
@@ -75,7 +75,7 @@ export const Twirl = ((props) => (
           ...o.barStyles,
           width: `${o.width}px`,
           top: `${o.topOffset + o.barHeight * 2 + o.margin * 2}px`,
-          transition: `${o.time / 2}s ${o.easing} ${o.isToggled
+          transition: `transform ${o.time / 2}s ${o.easing} ${o.isToggled
             ? `${o.time / 2}s`
             : '0s'
           }`,

--- a/tests/duration.test.tsx
+++ b/tests/duration.test.tsx
@@ -5,17 +5,17 @@ import { render, screen } from '@testing-library/react'
 it(`can be set as float`, () => {
   render(<Hamburger duration={0.4} />)
 
-  expect(screen.getByTestId('bar-one')).toHaveStyle({ transition: '0.4s cubic-bezier(0, 0, 0, 1)' })
+  expect(screen.getByTestId('bar-one')).toHaveStyle({ transition: 'transform 0.4s cubic-bezier(0, 0, 0, 1)' })
 })
 
 it(`can be set as integer`, () => {
   render(<Hamburger duration={2} />)
 
-  expect(screen.getByTestId('bar-one')).toHaveStyle({ transition: '2s cubic-bezier(0, 0, 0, 1)' })
+  expect(screen.getByTestId('bar-one')).toHaveStyle({ transition: 'transform 2s cubic-bezier(0, 0, 0, 1)' })
 })
 
 it(`calculates delay`, () => {
   render(<Squash duration={1.4} />)
 
-  expect(screen.getByTestId('bar-wrap-one')).toHaveStyle({ transition: '0.7s cubic-bezier(0, 0, 0, 1) 0.7s' })
+  expect(screen.getByTestId('bar-wrap-one')).toHaveStyle({ transition: 'transform 0.7s cubic-bezier(0, 0, 0, 1) 0.7s' })
 })

--- a/tests/easing.test.tsx
+++ b/tests/easing.test.tsx
@@ -5,11 +5,11 @@ import { render, screen } from '@testing-library/react'
 it(`has a default cubic timing`, () => {
   render(<Hamburger duration={0.2} />)
 
-  expect(screen.getByTestId('bar-one')).toHaveStyle({ transition: '0.2s cubic-bezier(0, 0, 0, 1)' })
+  expect(screen.getByTestId('bar-one')).toHaveStyle({ transition: 'transform 0.2s cubic-bezier(0, 0, 0, 1)' })
 })
 
 it(`sets the correct size`, () => {
   render(<Hamburger duration={0.2} easing="ease-out" />)
 
-  expect(screen.getByTestId('bar-one')).toHaveStyle({ transition: '0.2s ease-out' })
+  expect(screen.getByTestId('bar-one')).toHaveStyle({ transition: 'transform 0.2s ease-out' })
 })


### PR DESCRIPTION
For now, in this project, transitions are reacting to any kind of changes. In some cases, if something change on burger hover for example, transitions are wrongly triggered.

This fix allows transitions to be triggered only on css transform property change, allowing external interactions on the burger (background color change, etc).